### PR TITLE
Fix redundant forward passes in POS and DP processors

### DIFF
--- a/gr_nlp_toolkit/processors/dp.py
+++ b/gr_nlp_toolkit/processors/dp.py
@@ -62,20 +62,14 @@ class DP(AbstractProcessor):
             Document: The document with head and deprel tags assigned to the tokens.
         """
 
-        # Predict heads
+        # Single forward pass - model returns both heads and deprels
         input_ids, text_len = next(iter(doc.dataloader))['input']
+        output = self._model(input_ids.to(self.device), text_len.to(self.device))
 
-        output_heads = 'heads'
-       
-        predictions_heads = self._model(input_ids.to(self.device), text_len.to(self.device))
-        predictions_heads = self.softmax(predictions_heads[output_heads])
+        predictions_heads = self.softmax(output['heads'])
         predictions_heads = torch.argmax(predictions_heads[0], axis=-1).detach().cpu().numpy()
 
-        # Predict dependency relations (deprels)
-        output_deprels = 'gathered_deprels'
-        
-        predictions_deprels = self._model(input_ids.to(self.device), text_len.to(self.device))
-        predictions_deprels = self.softmax(predictions_deprels[output_deprels])
+        predictions_deprels = self.softmax(output['gathered_deprels'])
         predictions_deprels = torch.argmax(predictions_deprels[0], axis=-1).detach().cpu().numpy()
 
         # map predictions -> tokens, special tokens are not included

--- a/gr_nlp_toolkit/processors/pos.py
+++ b/gr_nlp_toolkit/processors/pos.py
@@ -68,12 +68,12 @@ class POS(AbstractProcessor):
 
         input_ids, text_len = next(iter(doc.dataloader))['input']
 
-        for feat in self.feat_to_I2L.keys():
-            output = self._model(input_ids.to(self.device), text_len.to(self.device))
-            output = self.softmax(output[feat])
+        # Single forward pass - the model returns all features at once
+        output = self._model(input_ids.to(self.device), text_len.to(self.device))
 
-            
-            predictions[feat] = torch.argmax(output[0], axis=-1).detach().cpu().numpy()
+        for feat in self.feat_to_I2L.keys():
+            feat_output = self.softmax(output[feat])
+            predictions[feat] = torch.argmax(feat_output[0], axis=-1).detach().cpu().numpy()
 
         # set upos
         upos_predictions = predictions['upos']


### PR DESCRIPTION
POS processor was calling `self._model()` once per feature (17 times) in a loop, discarding 16/17 outputs each time. The model returns all features in a single forward pass. Changed to call the model once and read all feature outputs from the result dict.

DP processor had the same issue: calling `self._model()` twice (once for heads, once for deprels) when both come from the same forward pass.

Result: ~8.5x speedup on POS+DP tagging (19 BERT passes -> 2 per sentence).
Benchmarked on 611-line Greek text: 126s -> 14.9s.