### PR TITLE
Fix docs wording, heading style, and test/code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For example:
 
   A small detail is that to get the `Token` object that is the head of another token you need to access
   `doc.tokens[head-1]`. The reason for this is that the enumeration of the tokens starts from 1 and when the
-  field `token.head` is set to 0, that means the token is the root of the word.
+  field `token.head` is set to 0, that means the token is the root of the sentence.
 
 - Greeklish to Greek Conversion (input text in Greeklish)
 
@@ -145,8 +145,7 @@ If you use our toolkit, please cite it:
 }
 ```
 
-----
-### Technical Notes:
+## Technical Notes
 
 - The *first* time you use a processor, the models are downloaded from Hugging Face and stored into the .cache folder. The NER, DP and POS processors are each about 500 MB, while the G2G processor is about 1.2 GB in size.
 - If the input text is already in Greek, the G2G (Greeklish-to-Greek) processor is skipped.

--- a/gr_nlp_toolkit/domain/document.py
+++ b/gr_nlp_toolkit/domain/document.py
@@ -9,8 +9,8 @@ class Document:
         """
         Create a Document object setting possible parameters other than the text as None
 
-        Keyword arguments:
-        param text: The text of the document
+        Args:
+            text: The text of the document
         """
         self._text = text
 
@@ -63,7 +63,7 @@ class Document:
     @property
     def token_mask(self):
         """
-        A tensor of shape [1,mseq] containign zeros at the positions of the input_ids tensor that map to subword tokens that are non first subword tokens
+        A tensor of shape [1,mseq] containing zeros at the positions of the input_ids tensor that map to subword tokens that are non first subword tokens
         """
         return self._token_mask
 

--- a/gr_nlp_toolkit/pipeline/pipeline.py
+++ b/gr_nlp_toolkit/pipeline/pipeline.py
@@ -65,12 +65,12 @@ class Pipeline:
         Initializes the pipeline with the specified processors
 
         Args:
-            processors: A string with the names of the processors you want to load, available values: 'ner', 'por', 'dp
+            processors: A string with the names of the processors you want to load, available values: 'ner', 'pos', 'dp', 'g2g', 'g2g_lite'
             use_cpu: A boolean that specifies if the pipeline will run on the CPU
         """
 
         # if the user wants to use the CPU, we set the device to 'cpu'
-        if(use_cpu):
+        if use_cpu:
             self.device = "cpu"
         else:
             self.device = get_device_name()
@@ -80,7 +80,7 @@ class Pipeline:
         processors = set(processors.split(","))
 
         # ner: Named Entity Recognition Processor 
-        # pos: Part of Speech Recognition Processor
+        # pos: Part-of-Speech Tagging Processor
         # dp: Dependency Parsing 
         # g2g: Greeklish to Greek Transliteration Processor (ByT5 model)
         # g2g_lite: Greeklish to Greek Transliteration Processor (LSTM model)
@@ -125,7 +125,6 @@ class Pipeline:
 
         # Pass the document through every processor
         for processor in self._processors:
-            # print(processor)
             processor(self._doc)
 
         return self._doc

--- a/tests/domain/test_token.py
+++ b/tests/domain/test_token.py
@@ -3,7 +3,7 @@ import unittest
 from gr_nlp_toolkit.domain.token import Token
 
 
-class MyTestCase(unittest.TestCase):
+class TestToken(unittest.TestCase):
     def test_new_token_object(self):
         token = Token(['α'])
         self.assertEqual(['α'], token.subwords)

--- a/tests/test_pipeline/test_pipeline.py
+++ b/tests/test_pipeline/test_pipeline.py
@@ -36,16 +36,6 @@ class TestPipeline(unittest.TestCase):
                 for feat, value in token.feats.items():
                     self.assertTrue(feat in pos_properties[token.upos])
                     self.assertTrue(value in pos_labels[feat])
-                    print(token.text, token.ner, token.upos, token.feats, token.head, token.deprel)
-                    self.assertIsNotNone(token.ner)
-                    self.assertTrue(token.ner in ner_labels)
-                    self.assertIsNotNone(token.head)
-                    self.assertIsNotNone(token.deprel)
-                    # We have to add plus one, because the cls token is removed
-                    self.assertTrue(token.head in range(0, len(doc.tokens) + 1))
-                    self.assertTrue(token.deprel in dp_labels)
-                    self.assertIsNotNone(token.upos)
-                    self.assertTrue(token.upos in pos_labels['upos'])
 
     def test_annotations_are_same_with_multiple_configurations(self):
         nlp = Pipeline('dp,pos,ner,g2g')


### PR DESCRIPTION
## Summary

- **README**: fix factual error ("root of the word" → "root of the sentence"), normalize `Technical Notes` to a proper `##` heading
- **pipeline.py**: fix docstring typo (`'por'` → `'pos'`, add missing `g2g`/`g2g_lite` values), remove parentheses from `if` statement, fix POS comment label, remove dead commented-out `print`
- **document.py**: fix typo `containign` → `containing`, normalize `__init__` docstring to `Args:` format (consistent with all other methods)
- **test_pipeline.py**: remove duplicate assertion block copy-pasted inside the `feats` loop — those checks were already covered by the outer token loop
- **test_token.py**: rename `MyTestCase` → `TestToken`

## Test plan

- [x] Full test suite run locally: **25/25 passed**